### PR TITLE
Wrong Enum Value Name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tmag5273"
 rust-version = "1.81" # required for core errors functionality when working with no-std environments
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = [
     "Scott Gibb <scott.gibb@dyson.com",
-    "Pete Kubiak <pete.kubiak@dyson.com>",
+    "Pete Kubiak <peter.kubiak@dyson.com>",
     "James Sizeland <james.sizeland@dyson.com>",
 ]
 repository = "https://stash.dyson.global.corp/projects/NEA/repos/rs-tmag5273-driver/browse"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ where
         // Set the Mag Channels to be enabled
         let sensor_config_1_register: SensorConfig1Register = self
             .get_config_register::<SensorConfig1Register>()?
-            .with_sleep_time(SleepTime::Ms10000)
+            .with_sleep_time(SleepTime::Ms20000)
             .with_mag_channel(MagneticChannel::XYZ);
         self.set_config_register(sensor_config_1_register)?;
 

--- a/src/registers/sensor_config_1.rs
+++ b/src/registers/sensor_config_1.rs
@@ -31,8 +31,8 @@ pub enum SleepTime {
     Ms2000 = 0xA,
     // 5000 ms
     Ms5000 = 0xB,
-    // 10000 ms
-    Ms10000 = 0xC,
+    // 20000 ms
+    Ms20000 = 0xC,
 }
 /// Enables data acquisition of the magnetic axis channel(s)
 /// This maps to MAG_CH_EN in the datasheet.


### PR DESCRIPTION
Found this when working with the driver and looking at power states.

![image](https://github.com/user-attachments/assets/ed542fbf-1b21-45cb-9c1f-1696aafa9fae)

We had put down 10000 when its actually 20000