### PR TITLE
fixed codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @ScottGibb
-* @petekubiak
-* @jamessizeland
+* @ScottGibb @petekubiak @jamessizeland


### PR DESCRIPTION
Syntax was incorrect. According to Athena this is what the syntax should be