### PR TITLE
Replaced glob

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,9 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directories:
-      - "**/*"
+      - "/" # Library Crate - This includes Workspace crates tests-common and utils based on the root Cargo.toml
+      - "/examples/*"
+      - "/tests/*"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
# Description

There was an issue encountered in the most recent Dependabot where it would not properly post PRs. This was due to the Dependabot relying on the workspace arguments of rust to do its dependency management. Specifically this was conflicting with the glob pattern `**/*`. What was happening was this was conflicting with the existing Cargo.toml workspace which is required for  MegaLinter to properly lint the library. This should hopefully fix that by splitting dependabot into different directories.

## Type of change

Please Tick the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Testing has to be done on the main Branch

## Checklist

- [ ] My code follows the style guidelines of this project (this should be caught by the CI)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (this should be caught by the CI)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
